### PR TITLE
Bump steward to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0]
+
+### Changed
+- Upgrade Steward from v1.2 to v3.1 and ArgoCD from v1.7.4 to 1.8.7 ([#4])
+
+### BREAKING CHANGES
+- The version v2.0.0 does use a statefulset instead of a deployment and is only compatible with ArgoCD 1.8.
+- It requires the argocd component v2.0.0.
+
 ## [v1.0.0]
 
 ### Changed
@@ -11,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Open source component ([#2])
 - Configure Argo CD image to be deployed ([#5])
 
-[Unreleased]: https://github.com/projectsyn/component-steward/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/projectsyn/component-steward/compare/v2.0.0...HEAD
 [v1.0.0]: https://github.com/projectsyn/component-steward/releases/tag/v1.0.0
+[v2.0.0]: https://github.com/projectsyn/component-steward/releases/tag/v2.0.0
 
 [#2]: https://github.com/projectsyn/component-steward/pull/2
+[#4]: https://github.com/projectsyn/component-steward/pull/4
 [#5]: https://github.com/projectsyn/component-steward/pull/5

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,4 +9,4 @@ parameters:
         tag: 'v0.3.1@sha256:066129ff4e932cd1f06097f637c6b2a993454f5bf0862ba530d8439ceb629129'
       argocd:
         image: docker.io/argoproj/argocd
-        tag: 'v1.7.4@sha256:d8a356b76d8b1bd810c9381f88ec0ae8cc71ad0ec2e22910a47f5c56417a40d0'
+        tag: 'v1.8.7@sha256:ce34acd7bac34d5a4fdbf96faf11fa5e01a7f96a27041d4472ca498886000cbf'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     images:
       steward:
         image: docker.io/projectsyn/steward
-        tag: 'v0.1.2@sha256:84db4eb4a87f442e75f9996c33be660811be7af9a1b753228f5a99d527f4b284'
+        tag: 'v0.3.1@sha256:066129ff4e932cd1f06097f637c6b2a993454f5bf0862ba530d8439ceb629129'
       argocd:
         image: docker.io/argoproj/argocd
         tag: 'v1.7.4@sha256:d8a356b76d8b1bd810c9381f88ec0ae8cc71ad0ec2e22910a47f5c56417a40d0'


### PR DESCRIPTION
Updates steward to v0.3.1 required by ArgoCD 1.8.

**Requires merging projectsyn/component-argocd#15 at the same time!**
