### PR TITLE
Bump steward to `v0.4.0` - Switches to ArgoCD 2.0.4

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     images:
       steward:
         image: docker.io/projectsyn/steward
-        tag: 'v0.3.1@sha256:066129ff4e932cd1f06097f637c6b2a993454f5bf0862ba530d8439ceb629129'
+        tag: 'v0.4.0@sha256:d6f5649899b7d006fc91a04da4272051924de5ff789ec8b8396ba370d21cdd09'
       argocd:
-        image: docker.io/argoproj/argocd
-        tag: 'v1.8.7@sha256:ce34acd7bac34d5a4fdbf96faf11fa5e01a7f96a27041d4472ca498886000cbf'
+        image: quay.io/argoproj/argocd
+        tag: 'v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348'


### PR DESCRIPTION
This PR updates Steward and ArgoCD to matching versions `v2.0.4`.

Also see https://github.com/projectsyn/component-argocd/pull/21.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
