### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   steward:
     namespace: syn
     api_url: 'https://api.syn.vshn.net/'
-    token: '?{vaultkv:${customer:name}/${cluster:name}/steward/token}'
+    token: '?{vaultkv:${cluster:tenant}/${cluster:name}/steward/token}'
     resources:
       requests:
         cpu: 100m

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -24,7 +24,7 @@ The URL of the Lieutenant API to which Steward should connect.
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/steward/token}`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/steward/token}`
 
 The API token for the Lieutenant API to which Steward should connect.
 By default, the component is configured to fetch the API token from Vault.


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
