### PR TITLE
Add label for PRs that get auto-merged by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,8 @@
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": ">=1.0.0",
       "automerge": true,
-      "platformAutomerge": false
+      "platformAutomerge": false,
+      "labels": ["automerge"]
     }
   ]
 }


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
