### PR TITLE
Fix Renovate JSON syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
         "bump:minor"
       ],
       "matchPackagePatterns": [
-        "^docker.io/projectsyn/steward$",
+        "^docker.io/projectsyn/steward$"
       ]
     }
   ]


### PR DESCRIPTION
Renovate is currently reporting a configuration error in #110 and stopping PR creation.

This removes the trailing comma in `renovate.json` so the file parses as valid JSON again. I kept the change intentionally narrow and did not alter package rules, automerge behavior, labels, or post-upgrade tasks.

Validation run locally:

```bash
python3 -m json.tool renovate.json
```

This is a small public-config cleanup to get Renovate unstuck.