### PR TITLE
Fix handling objects in additional-facts configmaps

### DIFF
--- a/component/espejote-templates/manage-additional-facts.jsonnet
+++ b/component/espejote-templates/manage-additional-facts.jsonnet
@@ -59,5 +59,8 @@ local mergeFacts(configmaps, facts) =
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: targetMetadata(configmapsFacts),
-  data: mergeFacts(configmapsFacts, facts),
+  data: std.mapWithKey(
+    function(_, v) if std.isString(v) then v else std.manifestJsonMinified(v),
+    std.prune(mergeFacts(configmapsFacts, facts))
+  ),
 }

--- a/tests/golden/defaults/steward/steward/20_additional_facts.yaml
+++ b/tests/golden/defaults/steward/steward/20_additional_facts.yaml
@@ -173,7 +173,10 @@ spec:
       apiVersion: 'v1',
       kind: 'ConfigMap',
       metadata: targetMetadata(configmapsFacts),
-      data: mergeFacts(configmapsFacts, facts),
+      data: std.mapWithKey(
+        function(_, v) if std.isString(v) then v else std.manifestJsonMinified(v),
+        std.prune(mergeFacts(configmapsFacts, facts))
+      ),
     }
   triggers:
     - name: jsonnetlib


### PR DESCRIPTION
This fixes an issue when external configmaps containing objects as additional facts. If the fact is not a string it will be converted into a minified JSON string.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
